### PR TITLE
Install caddy-umami module

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,4 +37,3 @@ jobs:
           KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
           TARGET: "/home/website/thenewoil/"
           ARGS: '-z -r -v -l -t --delete-after --exclude node_modules/ .git/'
-

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   to_gitlab:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/validate-caddy.yml
+++ b/.github/workflows/validate-caddy.yml
@@ -1,0 +1,18 @@
+name: Validate Caddyfile
+on:
+  push:
+    paths:
+      - 'caddy/**'
+  pull_request:
+    paths:
+      - 'caddy/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Files
+        uses: actions/checkout@main
+      - name: Validate Caddyfile
+        run: |
+          docker run -v ./caddy:/data ghcr.io/jonaharagon/caddy-build:latest caddy validate --config /data/Caddyfile

--- a/caddy/50-stats.caddy
+++ b/caddy/50-stats.caddy
@@ -1,0 +1,7 @@
+(umami) {
+	umami {
+		event_endpoint "https://stats.thenewoil.org/api/send"
+		website_uuid "0cdf6f5b-9b3b-4815-9d22-8cb4d6132781"
+		device_detection
+	}
+}

--- a/caddy/90-clearnet.caddy
+++ b/caddy/90-clearnet.caddy
@@ -1,6 +1,11 @@
 # Remember to change the number in ./Caddyfile after editing this file too!
 
 thenewoil.org {
+	@file file
+	route @file {
+		import umami
+	}
+
 	# These two lines configure Caddy to serve from the www subdirectory of this repo
 	# see: https://caddyserver.com/docs/caddyfile/directives/file_server
 	root * /home/website/thenewoil/www

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,4 +1,4 @@
-# VERSION: 4
+# VERSION: 5
 # You should increment this number whenever changing ANY file in the /caddy folder, so that the webserver picks up the changes and restarts
 
 # Imports the configuration from all files in this folder with the .caddy file extension

--- a/docs/server/install.md
+++ b/docs/server/install.md
@@ -47,25 +47,46 @@ systemctl restart sshd
 
 ## Step 2. Webserver Install
 
-1. [Install Caddy](https://caddyserver.com/docs/install#debian-ubuntu-raspbian)
+1. [Install Caddy](https://caddyserver.com/docs/install#debian-ubuntu-raspbian) with apt
 
-<details>
-<summary>Why Caddy?</summary>
+    <details>
+    <summary>Why Caddy?</summary>
 
-Trust me on this one. It's way easier to use than Nginx, and also plain better. Creating a website in Caddy is as simple as adding 4 lines to `/etc/caddy/Caddyfile`:
+    Trust me on this one. It's way easier to use than Nginx, and also plain better. Creating a website in Caddy is as simple as adding 4 lines to `/etc/caddy/Caddyfile`:
 
-```text
-example.com {
-  root * /var/www/html
-  file_server
-}
-```
+    ```text
+    example.com {
+    root * /var/www/html
+    file_server
+    }
+    ```
 
-Simply doing this creates the website, grabs an SSL certificate, and everything is configured with very sane/modern defaults (HTTP/2 and HTTP/3, automatic HTTPS redirects, [etc.](https://caddyserver.com/features)).
+    Simply doing this creates the website, grabs an SSL certificate, and everything is configured with very sane/modern defaults (HTTP/2 and HTTP/3, automatic HTTPS redirects, [etc.](https://caddyserver.com/features)).
 
-With Nginx, you'd have to at minimum configure `/etc/nginx/nginx.conf`, `/etc/nginx/sites-enabled/your-website.conf`, **and** install Certbot, set up your certificates and renewal jobs; and chances are it still won't be configured as good as it could be unless you've taken the time to tweak every Nginx setting. Boo.
+    With Nginx, you'd have to at minimum configure `/etc/nginx/nginx.conf`, `/etc/nginx/sites-enabled/your-website.conf`, **and** install Certbot, set up your certificates and renewal jobs; and chances are it still won't be configured as good as it could be unless you've taken the time to tweak every Nginx setting. Boo.
 
-</details>
+    </details>
+
+2. Download a customized build of Caddy:
+
+    ```
+    wget https://github.com/jonaharagon/caddy-build/releases/latest/download/caddy-linux-amd64
+    ```
+
+    - You can get a copy of this from anywhere, like go to https://caddyserver.com/download, search for "umami", select that plugin to add it to the build, and download Caddy from that website instead. **But** that download site has been unreliable lately, so that's why I'm linking to a pre-built one.
+
+3. Now we have to replace the Caddy we just installed with a custom version which includes the [caddy-umami](https://github.com/jonaharagon/caddy-umami) plugin:
+
+    ```
+    sudo dpkg-divert --divert /usr/bin/caddy.default --rename /usr/bin/caddy
+    chmod +x caddy-linux-arm64
+    sudo mv ./caddy-linux-arm64 /usr/bin/caddy.custom
+    sudo update-alternatives --install /usr/bin/caddy caddy /usr/bin/caddy.default 10
+    sudo update-alternatives --install /usr/bin/caddy caddy /usr/bin/caddy.custom 50
+    sudo systemctl restart caddy
+    ```
+
+    - There's an explanation of what these commands do [here](https://caddyserver.com/docs/build#package-support-files-for-custom-builds-for-debianubunturaspbian).
 
 ## Step 3. Create User
 

--- a/docs/server/updates.md
+++ b/docs/server/updates.md
@@ -1,0 +1,20 @@
+# Server Updates
+
+## Caddy Updates
+
+After installing a customized build of Caddy `apt` will no longer give you Caddy updates, unfortunately. To update caddy, you can run [`caddy upgrade`](https://caddyserver.com/docs/command-line#caddy-upgrade):
+
+```
+caddy upgrade
+systemctl restart caddy
+```
+
+Alternatively (i.e. if that doesn't work) you can download a [pre-built copy of Caddy](https://github.com/jonaharagon/caddy-build/releases/latest) which includes the modules you have installed:
+
+```
+wget https://github.com/jonaharagon/caddy-build/releases/latest/download/caddy-linux-amd64
+chmod +x caddy-linux-arm64
+sudo mv ./caddy-linux-arm64 /usr/bin/caddy.custom
+caddy validate --config /etc/caddy/Caddyfile
+systemctl restart caddy
+```


### PR DESCRIPTION
Before merging, what you would do on your server is:

```
wget https://github.com/jonaharagon/caddy-build/releases/latest/download/caddy-linux-amd64
chmod +x caddy-linux-arm64
sudo dpkg-divert --divert /usr/bin/caddy.default --rename /usr/bin/caddy
sudo mv ./caddy-linux-arm64 /usr/bin/caddy.custom
sudo update-alternatives --install /usr/bin/caddy caddy /usr/bin/caddy.default 10
sudo update-alternatives --install /usr/bin/caddy caddy /usr/bin/caddy.custom 50
sudo systemctl restart caddy
```

Explanation of these commands is in the PR. Closes #10 