### PR TITLE
fix: correct link for Standard Notes

### DIFF
--- a/src/assets/data/pages/en/guides/most-important/MobileApps.json
+++ b/src/assets/data/pages/en/guides/most-important/MobileApps.json
@@ -63,7 +63,7 @@
           "[Joplin](https://joplinapp.org/)",
           "[Nextcloud](https://nextcloud.com/)",
 		  "[Notesnook](https://notesnook.com/)",
-		  "[Standard Notes](https://organicmaps.app/)"
+		  "[Standard Notes](https://standardnotes.com/)"
         ],
         "Reason": "Google and Apple have access to the files within the stock note-taking app by default. These services protect your notes in such a way that only you can see them while still providing cloud-syncing functionality."
       }


### PR DESCRIPTION
Previous link was incorrect.