### PR TITLE
Fix Ghost URL

### DIFF
--- a/src/assets/data/pages/en/links/PodcastsNewsAndBlog.json
+++ b/src/assets/data/pages/en/links/PodcastsNewsAndBlog.json
@@ -13,7 +13,7 @@
   },
   {
     "name": "Ghost",
-    "link": "https://thenewoil.ghost.io/",
+    "link": "https://ghost.thenewoil.org/",
     "img": "/images/logos/ghost.png"
   },
   {


### PR DESCRIPTION
Change https://thenewoil.ghost.io/ to https://ghost.thenewoil.org/ (accurate URL)